### PR TITLE
Added an 'attributes' member to the config object

### DIFF
--- a/lib/jasmine-fixture.js
+++ b/lib/jasmine-fixture.js
@@ -7,7 +7,8 @@
         cssClass:'',
         id:'',
         text: '',
-        defaultAttribute: 'class'
+        defaultAttribute: 'class',
+        attributes: {}
       };
 
   window.jasmineFixture = function($) {
@@ -49,10 +50,10 @@
     };
 
     var applyAttributes = function($html,config) {
-      var attrs = {
+      var attrs = $.extend({},{
         id: config.id,
         'class': config['class'] || config.cssClass
-      };
+      }, config.attributes);
       if(isString(config.userString)) {
         attrs[config.defaultAttribute] = config.userString;
       }

--- a/spec/jasmine-fixture-spec.js
+++ b/spec/jasmine-fixture-spec.js
@@ -84,6 +84,15 @@ describe('Jasmine Fixture',function(){
           });
         });
 
+        context("passed additional attributes to be applied in the config object", function() {
+          beforeEach(function() {
+            $result = $.jasmine.inject({ el: 'script', attributes: { type: 'text/template' } });
+          });
+
+          it("applies the additional attributes", function() {
+            expect($result.attr('type')).toEqual('text/template');
+          });
+        });
       });
 
       describe("#configure", function() {


### PR DESCRIPTION
I added this when I ran into a problem trying to inject a `<script type="text/template"><%= myMember %></script>` using the config object for a Backbone View.  Obviously it worked injecting by string, but looks nicer with the config object.
