### PR TITLE
handle attributes that contain `[` and `]`  (Issue #7)

### DIFF
--- a/dist/jasmine-fixture.js
+++ b/dist/jasmine-fixture.js
@@ -478,7 +478,7 @@ site: https://github.com/searls/jasmine-fixture
     regReference = /(@[\w$_][\w$_\d]+)/i;
     regAttrDfn = /(\[([\w-!]+(="?([^"]|\\")+"?)? {0,})+\])/ig;
     regAttrs = /([\w-!]+(="([^"]|\\")+")?)/g;
-    regAttr = /([\w-!]+)(="?(([^"\]]|\\")+)"?)?/i;
+    regAttr = /([\w-!]+)(="?((([\w]+\[.*?\])|[^"\]]|\\")+)"?)?/i;
     regCBrace = /\{(([^\}]|\\\})+)\}/i;
     regExclamation = /(?:([^\\]|^))!([^!]|\\!)+!/g;
     regEvents = /\~[\w$]+(=[\w$]+)?/g;

--- a/spec/affix-spec.coffee
+++ b/spec/affix-spec.coffee
@@ -32,6 +32,7 @@ describe "jasmine-fixture 1.x", ->
       'div[data-bind="my_item"]'                                              #<div data-bind="my_item"></div>
       '.ui-dialog[style="width: 1px; height: 5px"]'                           #<div style="width: 1px; height: 5px" class="ui-dialog"></div>
       '#toddler .hidden.toy input[name="toyName"][value="cuddle bunny"]'      #<div id="toddler"><div class="hidden toy"><input name="toyName" value="cuddle bunny"></div></div>
+      'select[name="date[year]"]'                                             #<select name="date[year]"></select>
     ]
 
     for selector in EXAMPLES
@@ -60,3 +61,4 @@ describe "jasmine-fixture 1.x", ->
       When -> @$result = @$container.affix('#content')
       Then -> expect(@$container).toHas('#content')
       Then -> expect(@$result).toIs('#content')
+

--- a/src/jasmine-fixture.coffee
+++ b/src/jasmine-fixture.coffee
@@ -353,7 +353,19 @@ createHTMLBlock = ( ->
   regReference = /(@[\w$_][\w$_\d]+)/i
   regAttrDfn = /(\[([\w-!]+(="?([^"]|\\")+"?)? {0,})+\])/ig
   regAttrs = /([\w-!]+(="([^"]|\\")+")?)/g
-  regAttr = /([\w-!]+)(="?(([^"\]]|\\")+)"?)?/i
+  regAttr = ///
+             ([\w-!]+)  #one or more combination of words, - (dashes), and ! (bang)
+             (="?            # equals sign (=), followed by optional double quote
+             (             
+                             # one or more of the following three:
+             (                            
+             ([\w]+\[.*?\])  # 1) one or more words, followed by brackets with any chars
+             |[^"\]]         # 2) anything except double quote and closing bracket 
+             | \\")+         # 3) double quote
+             )
+             "?)             # optional double quote
+             ?   # .... the preceding parenthesized expression zero (0) or one (1) time
+        ///i
   regCBrace = /\{(([^\}]|\\\})+)\}/i
   regExclamation = /(?:([^\\]|^))!([^!]|\\!)+!/g
   regEvents = /\~[\w$]+(=[\w$]+)?/g


### PR DESCRIPTION
I added a spec for containing the expression in the issue and the specs passed.

The regex might be a little too permissive -- I used ".*" inside of `[` and `]`.

Thoughts?
