### PR TITLE
Allow me to use the logic that creates nodes without having to attach th...

### DIFF
--- a/app/js/jasmine-fixture.coffee
+++ b/app/js/jasmine-fixture.coffee
@@ -4,6 +4,7 @@
   originalJasmineFixture = root.jasmineFixture
   originalInject = root.inject
   originalAffix = root.affix
+  originalCreate = root.create
 
   _ = (list) ->
     inject: (iterator, memo) ->
@@ -11,16 +12,22 @@
 
   root.jasmineFixture = ($) ->
     #--------------------------------------------------------
-    # #affix (jasmine-fixture 1.x)
-    $.fn.affix = root.affix = (selectorOptions) ->
+    # #create (jasmine-fixture 1.x)
+    $.fn.create = root.create = (selectorOptions, attach) ->
       $top=null
       _(selectorOptions.split(/[ ](?=[^\]]*?(?:\[|$))/)).inject(($parent, elementSelector) ->
         return $parent if elementSelector == ">"
-        $el = createHTMLBlock($,elementSelector).appendTo($parent)
+        $el = createHTMLBlock($,elementSelector)
+        $el.appendTo($parent) if $parent
         $top ||= $el
         $el
-      , $whatsTheRootOf(this))
+      , if attach then $whatsTheRootOf(@) else null)
       $top
+
+    #--------------------------------------------------------
+    # #affix (jasmine-fixture 1.x)
+    $.fn.affix = root.affix = (selectorOptions) ->
+      create(selectorOptions, true)
 
     $whatsTheRootOf = (that) ->
       if that.jquery?
@@ -72,6 +79,7 @@
         root.jasmineFixture = originalJasmineFixture
         root.inject = originalInject
         root.affix = originalAffix
+        root.create = originalCreate
         this
 
     $.fn.inject = (html) ->


### PR DESCRIPTION
...em

This is a pretty simple PR that allows me to create nodes in-memory but not in the DOM. I find jasmine-fixture to be really useful, but I also have plenty of tests to do where I'm passing around nodes that may not be attached (they came from the server, or were constructed by a template, etc).

Enables something like this:

```
describe 'FooBar', ->
  it 'adds new elements to the existing content', ->
    affix('#root') #as before
    newContent = create('#root #child', false) #now I can do this!
    fb = new FooBar(newContent)
    ...
```
