### PR TITLE
Trims selector strings to ignore whitespaces

### DIFF
--- a/app/js/jasmine-fixture.coffee
+++ b/app/js/jasmine-fixture.coffee
@@ -15,7 +15,7 @@
 
     create = (selectorOptions, attach) ->
       $top=null
-      _(selectorOptions.split(/[ ](?![^\{]*\})(?=[^\]]*?(?:\[|$))/)).inject(($parent, elementSelector) ->
+      _(selectorOptions.trim().split(/[ ](?![^\{]*\})(?=[^\]]*?(?:\[|$))/)).inject(($parent, elementSelector) ->
         return $parent if elementSelector == ">"
         $el = createHTMLBlock($,elementSelector)
         $el.appendTo($parent) if attach || $top

--- a/spec/jasmine-fixture-spec.coffee
+++ b/spec/jasmine-fixture-spec.coffee
@@ -26,7 +26,8 @@ describe "jasmine.fixture", ->
      '#toddler .hidden.toy input[name="toyName"][value="cuddle bunny"]'    #<div id="toddler"><div class="hidden toy"><input name="toyName" value="cuddle bunny"></div></div>
      'select[name="date[year]"]'                                           #<select name="date[year]"></select>
      'input[name="some[thing][foo]"]'
-     'input[type="text"][value="4.99"][class="class-name"]'
+     'input[type="text"][value="4.99"][class="class-name"]',
+     '     #foo .bar    '
   ]
 
   describe ".affix", ->


### PR DESCRIPTION
By accident we ran into an issue when a selector ends with a whitespace.
Calling `affix(".foo #bar ")` (mind the space at the end) results in the error message `$el.appendTo is not a function`.

To accommodate some developer sloppiness I thought a `trim()` could help here.