### PR TITLE
prevent load-order bugs where jQuery is loaded after jasmine-fixture

### DIFF
--- a/app/js/jasmine-fixture.coffee
+++ b/app/js/jasmine-fixture.coffee
@@ -39,15 +39,16 @@
       else
         $('<div id="jasmine_content"></div>').appendTo('body')
 
+    ewwSideEffects = (jasmineFixture) ->
+      root.jasmine?.fixture = jasmineFixture
+      $.fn.affix = root.affix = jasmineFixture.affix
+      afterEach ->
+        $('#jasmine_content').remove()
+
     jasmineFixture = {affix, create, noConflict}
     ewwSideEffects(jasmineFixture)
     return jasmineFixture
 
-  ewwSideEffects = (jasmineFixture) ->
-    root.jasmine?.fixture = jasmineFixture
-    $.fn.affix = root.affix = jasmineFixture.affix
-    afterEach ->
-      $('#jasmine_content').remove()
 
   if $
     jasmineFixture = root.jasmineFixture($)


### PR DESCRIPTION
@herine-chin and I were setting up a Rails codebase with jasmine-rails to write it's first javascript unit tests and discovered unless we load jQuery *before* jasmine-fixture; jasmine-fixture explodes. 

This fixes that; though we weren't *quite* sure how to test this, seeing as we'd need to re-execute the anonymous function in order to do so; (Perhaps we could call `root`?) but here's the basic rundown:

1. `ewwSideEffects` is a direct child of the top-level anonymous functions closure; which gets evaluated at interpretation time. It then mutates the root closures reference of `$`; which happens to be whatever `window.jQuery || window.$` is when the file is loaded.
2. root.jasmineFixture may be called later on; for instance once `affix` is called for the first time. In doing so it calls `ewwSideEffects`; resulting in above mutation of root's `$`
3. Howeeevvveeeerrrrrrrr in cases where jQuery is loaded *after* `affix`; root's `$` is undefined!
4. So, I moved `ewwSideEffects` into a child of `jasmineFixture` so that it mutates the `jasmineFixture` reference to `$`; which will be whatever `window.$ || window.jQuery` is at the initial call to `affix`

Thoughts on testing strategy?

