### PR TITLE
Allow affixing tags with dashes in their name (e.g. Angular directives)

### DIFF
--- a/spec/jasmine-fixture-spec.coffee
+++ b/spec/jasmine-fixture-spec.coffee
@@ -2,6 +2,7 @@ describe "jasmine.fixture", ->
 
   EXAMPLES = [
      'article'                                                             #<article></article>
+     'backlog-item'                                                        #<backlog-item></backlog-item>
      '.foo'                                                                #<div class="foo"></div>
      '.foo-hah'                                                            #<div class="foo-hah"></div>
      '#blah-blah'                                                          #<div id="blah-blah"></div>


### PR DESCRIPTION
fixes #47 
